### PR TITLE
remove the active word from the Slide.js

### DIFF
--- a/src/ui/site/ContentSlides/common/Slide.js
+++ b/src/ui/site/ContentSlides/common/Slide.js
@@ -66,7 +66,7 @@ const Slide = ({
     >
       { title }
       { children }
-      <p className='c-on-z'>{ active && ' active' }</p>
+      <p className='c-on-z'>{ active && '' }</p>
     </Wrapper>
   )}
 

--- a/src/ui/site/ContentSlides/common/Slide.js
+++ b/src/ui/site/ContentSlides/common/Slide.js
@@ -66,7 +66,6 @@ const Slide = ({
     >
       { title }
       { children }
-      <p className='c-on-z'>{ active && '' }</p>
     </Wrapper>
   )}
 


### PR DESCRIPTION
 the active word would display on the slider in ContentSlides.js story under the button, disrupting the main design